### PR TITLE
Strengthen portfolio positioning and AI-enabled services

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -84,7 +84,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
       <article class="principle-item"><span>01</span><h3>Make the problem legible</h3><p>A team moves faster when the real constraint is clear and the language around it is precise.</p></article>
       <article class="principle-item"><span>02</span><h3>Prototype the uncertainty</h3><p>The first build should answer the hardest question, not simply produce the easiest visible progress.</p></article>
       <article class="principle-item"><span>03</span><h3>Keep presentation honest</h3><p>Polish should reveal the product’s value and boundaries, not decorate around missing substance.</p></article>
-      <article class="principle-item"><span>04</span><h3>Use automation deliberately</h3><p>Automate repeatable production while keeping judgment, review, and responsibility with a person.</p></article>
+      <article class="principle-item"><span>04</span><h3>Keep judgment in the loop</h3><p>Use AI and automation to accelerate exploration and repeatable production while keeping verification, product judgment, and responsibility with a person.</p></article>
     </div>
   </section>
 

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="About" description="About Stoyan Korudzhiev, a software engineer and product builder with deep Android roots and a broader end-to-end product practice.">
+<BaseLayout title="About" description="About Stoyan Korudzhiev, a software engineer and product builder working across product architecture, Android, web, desktop, and end-to-end product delivery.">
   <header class="page-intro about-page-intro shell">
     <p class="eyebrow">About</p>
     <h1>Engineering depth.<br />A wider product lens.</h1>
@@ -11,18 +11,67 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 
   <section class="page-section about-page-section shell">
     <div class="about-timeline">
-      <article class="timeline-item"><span>Foundation</span><h3>Mobile engineering</h3><p>Android taught me to take constraints, lifecycle, performance, edge cases, and the last mile to a real user seriously.</p></article>
-      <article class="timeline-item"><span>Expansion</span><h3>Complete products</h3><p>Building my own products pulled me into web and desktop engineering, product definition, interaction design, positioning, and release work.</p></article>
-      <article class="timeline-item"><span>Today</span><h3>Connected systems</h3><p>I increasingly work on the connections: code to product, tokens to interface, interface to launch assets, and rough intent to a coherent experience.</p></article>
+      <article class="timeline-item"><span>Foundation</span><h2>Mobile engineering</h2><p>Android taught me to take constraints, lifecycle, performance, edge cases, and the last mile to a real user seriously.</p></article>
+      <article class="timeline-item"><span>Deepening</span><h2>Product architecture</h2><p>That foundation grew into a focus on boundaries, state, data flow, testability, and code that can change without turning every feature into a rewrite.</p></article>
+      <article class="timeline-item"><span>Expansion</span><h2>Complete products</h2><p>I now carry those engineering standards across desktop and web products, product definition, interaction design, release work, and launch.</p></article>
     </div>
   </section>
 
   <section class="story-grid about-story-grid shell">
-    <div><p class="eyebrow">The through-line</p><h2>I like reducing ambiguity.</h2></div>
+    <div><p class="eyebrow">The through-line</p><h2>Make the problem—and the system—legible.</h2></div>
     <div class="story-copy">
-      <p>The most valuable engineering work often happens before the implementation is obvious: choosing the right boundary, understanding which interaction carries the product, and deciding what does not need to exist yet.</p>
-      <p>I care about the complete result. That includes technical structure, interface behavior, written language, visual coherence, documentation, and the way a product introduces itself to the market.</p>
+      <p>The most valuable engineering work often happens before the implementation is obvious: choosing the right boundary, making state and data flow understandable, identifying which interaction carries the product, and deciding what does not need to exist yet.</p>
+      <p>I care about the complete result. That includes a technical structure that can evolve, predictable interface behavior, written language, visual coherence, documentation, and the way a product introduces itself to the market.</p>
       <p><strong>This is not an agency story.</strong> It is a hands-on engineering practice that has grown wider by repeatedly taking products from idea to something real.</p>
+    </div>
+  </section>
+
+  <section class="about-architecture">
+    <div class="shell">
+      <div class="architecture-heading">
+        <div>
+          <p class="eyebrow">Under the product</p>
+          <h2>Architecture is how a product stays changeable.</h2>
+        </div>
+        <p>Most people should never need to care about layers or dependency direction. They do care when a small change becomes a rewrite, behavior is hard to predict, or ownership cannot move safely to another engineer.</p>
+      </div>
+
+      <div class="architecture-principles">
+        <article class="architecture-principle">
+          <span>01</span>
+          <h3>Keep change local</h3>
+          <p>Give domain logic, data access, platform integrations, and presentation clear responsibilities so a change in one place does not ripple through the whole product.</p>
+        </article>
+        <article class="architecture-principle">
+          <span>02</span>
+          <h3>Make behavior explicit</h3>
+          <p>Treat loading, empty, error, offline, lifecycle, and performance behavior as part of the system—not cleanup left until the happy path is finished.</p>
+        </article>
+        <article class="architecture-principle">
+          <span>03</span>
+          <h3>Build for continuation</h3>
+          <p>Earn abstractions through real needs, protect critical paths with tests, and document the decisions another engineer will need to change the system safely.</p>
+        </article>
+      </div>
+
+      <div class="architecture-evidence" aria-label="Architecture in selected work">
+        <article class="architecture-proof">
+          <h3>GitGlow</h3>
+          <p>A local Rust and Tauri foundation paired with a focused React interface.</p>
+        </article>
+        <article class="architecture-proof">
+          <h3>Continuum</h3>
+          <p>A local-first calculation workspace expressed across browser and macOS surfaces.</p>
+        </article>
+        <article class="architecture-proof">
+          <h3>Green Compass</h3>
+          <p>An Expo and TypeScript mobile product connected to Next.js web and Supabase data.</p>
+        </article>
+      </div>
+
+      <div class="architecture-link">
+        <a class="text-link" href="/work/">See the systems behind the products <span aria-hidden="true">→</span></a>
+      </div>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,7 +58,7 @@ const supportingWork = work.filter((project) => project.id !== "continuum");
   <div class="capability-band" aria-label="Areas of work">
     <div class="shell capability-list">
       <span>Product strategy</span><i>·</i>
-      <span>Engineering</span><i>·</i>
+      <span>Architecture &amp; engineering</span><i>·</i>
       <span>Mobile, web &amp; desktop</span><i>·</i>
       <span>Design systems</span><i>·</i>
       <span>Automation</span><i>·</i>
@@ -199,14 +199,14 @@ groceries - flexible</mark></pre>
         <ol class="practice-map__path">
           <li class="practice-map__origin"><span>Foundation</span><strong>Android</strong></li>
           <li><span>Surfaces</span><strong>Desktop + web</strong></li>
-          <li><span>Systems</span><strong>Strategy + design</strong></li>
-          <li><span>Delivery</span><strong>Automation + launch</strong></li>
+          <li><span>Architecture</span><strong>Built to evolve</strong></li>
+          <li><span>Delivery</span><strong>Product + launch</strong></li>
         </ol>
       </aside>
       <div class="about-copy">
         <p class="eyebrow">A broader engineering practice</p>
         <h2>Android was the foundation—not the boundary.</h2>
-        <p>Mobile engineering taught me to care about constraints, states, performance, and the last mile between code and a real person. Over time, that practice expanded into desktop and web products, product strategy, design systems, automation, and the work around a launch.</p>
+        <p>Mobile engineering taught me to care about constraints, explicit states, performance, and the last mile between code and a real person. I carry those standards into desktop and web products: clear boundaries, maintainable architecture, and the product systems that help good software keep evolving.</p>
         <a class="text-link" href="/about/">More about how I got here <span aria-hidden="true">→</span></a>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const supportingWork = work.filter((project) => project.id !== "continuum");
         <p class="eyebrow">Software engineer &amp; product builder</p>
         <h1>I turn ambiguous ideas into <em>polished</em> digital products.</h1>
         <p class="hero-lede">
-          I work across product thinking, engineering, design systems, and launch execution to turn rough ideas into useful, thoughtful software.
+          I work across product thinking, architecture, AI-assisted engineering, design systems, and launch execution to turn rough ideas into useful, thoughtful software.
         </p>
         <div class="button-row">
           <a class="button button--primary" href="/work/">View selected work <span aria-hidden="true">↗</span></a>
@@ -61,7 +61,7 @@ const supportingWork = work.filter((project) => project.id !== "continuum");
       <span>Architecture &amp; engineering</span><i>·</i>
       <span>Mobile, web &amp; desktop</span><i>·</i>
       <span>Design systems</span><i>·</i>
-      <span>Automation</span><i>·</i>
+      <span>AI + automation</span><i>·</i>
       <span>Launch execution</span>
     </div>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -191,7 +191,18 @@ groceries - flexible</mark></pre>
 
   <section class="section home-section">
     <div class="shell about-strip">
-      <div class="about-monogram" aria-hidden="true">SK</div>
+      <aside class="practice-map" aria-label="How the practice expanded from Android into broader product work">
+        <div class="practice-map__header">
+          <span>Practice map</span>
+          <span>01—04</span>
+        </div>
+        <ol class="practice-map__path">
+          <li class="practice-map__origin"><span>Foundation</span><strong>Android</strong></li>
+          <li><span>Surfaces</span><strong>Desktop + web</strong></li>
+          <li><span>Systems</span><strong>Strategy + design</strong></li>
+          <li><span>Delivery</span><strong>Automation + launch</strong></li>
+        </ol>
+      </aside>
       <div class="about-copy">
         <p class="eyebrow">A broader engineering practice</p>
         <h2>Android was the foundation—not the boundary.</h2>

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,11 +1,12 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 const services = (await getCollection("services")).sort((a, b) => a.data.order - b.data.order);
+const aiWorkflowArticle = await getEntry("writing", "design-system-marketing-engine");
 ---
 
-<BaseLayout title="How I can help" description="Product clarity, end-to-end engineering, launch systems, and technical product advisory from Stoyan Korudzhiev.">
+<BaseLayout title="How I can help" description="Product clarity, end-to-end engineering, AI-enabled delivery, launch systems, and technical product advisory from Stoyan Korudzhiev.">
   <header class="page-intro services-page-intro shell">
     <p class="eyebrow">How I can help</p>
     <h1>Useful when the product still has hard questions.</h1>
@@ -28,6 +29,45 @@ const services = (await getCollection("services")).sort((a, b) => a.data.order -
     ))}
   </section>
 
+  <section class="ai-delivery-section">
+    <div class="shell">
+      <div class="ai-delivery-heading">
+        <div>
+          <p class="eyebrow">AI-enabled delivery</p>
+          <h2>Models in the loop.<br />Judgment at the center.</h2>
+        </div>
+        <p>I use AI to shorten the path from an ambiguous question to a reviewed, useful output. The leverage comes from fitting models into a clear product workflow—not asking them to replace context, verification, or responsibility.</p>
+      </div>
+
+      <div class="ai-delivery-grid">
+        <article class="ai-delivery-step">
+          <span>01 · Explore</span>
+          <h3>Turn raw context into options.</h3>
+          <p>Synthesize research, test alternative directions, and create rapid prototypes before committing to the expensive path.</p>
+        </article>
+        <article class="ai-delivery-step">
+          <span>02 · Build</span>
+          <h3>Accelerate the critical path.</h3>
+          <p>Use engineering assistance for implementation, failure-case exploration, QA, tests, and documentation—then verify it against the real product.</p>
+        </article>
+        <article class="ai-delivery-step">
+          <span>03 · Operate</span>
+          <h3>Make repeatable work repeatable.</h3>
+          <p>Connect content variation, launch assets, and production steps into workflows with explicit review and approval points.</p>
+        </article>
+      </div>
+
+      <div class="ai-delivery-footer">
+        <p><strong>The guardrail:</strong> meaningful decisions and shipped output remain human-reviewed.</p>
+        {aiWorkflowArticle && (
+          <a class="text-link" href={aiWorkflowArticle.data.canonicalUrl} target="_blank" rel="noopener">
+            See an AI-assisted production system in practice <span aria-hidden="true">↗</span>
+          </a>
+        )}
+      </div>
+    </div>
+  </section>
+
   <section class="page-section services-page-section services-advisory-section shell">
     <div class="section-heading">
       <div><p class="eyebrow">A lighter format</p><h2>Technical product advisory.</h2></div>
@@ -36,7 +76,7 @@ const services = (await getCollection("services")).sort((a, b) => a.data.order -
     <div class="advisory-grid">
       <article class="advisory-card"><h3>Architecture and scope</h3><p>Review tradeoffs, reduce unnecessary surface area, and identify the risks worth solving early.</p></article>
       <article class="advisory-card"><h3>Product rescue planning</h3><p>Untangle a stalled product, clarify the critical path, and turn broad frustration into a workable sequence.</p></article>
-      <article class="advisory-card"><h3>AI-assisted workflows</h3><p>Design concrete, human-reviewed research, engineering, QA, and content workflows without “AI transformation” theatre.</p></article>
+      <article class="advisory-card"><h3>AI workflow review</h3><p>Identify where models can create useful leverage, define the guardrails, and turn the strongest opportunity into one small, testable workflow.</p></article>
     </div>
   </section>
 

--- a/src/site-config.ts
+++ b/src/site-config.ts
@@ -2,7 +2,7 @@ export const siteConfig = {
   name: "Stoyan Korudzhiev",
   title: "Software engineer & product builder",
   description:
-    "Software engineer and product builder working across product thinking, mobile, web, desktop, design systems, automation, and launch execution.",
+    "Software engineer and product builder working across product strategy, architecture, mobile, web, desktop, AI-assisted workflows, design systems, and launch execution.",
   url: "https://skorudzhiev.github.io",
   email: "skorudzhiev@gmail.com",
   availability: "conversations" as const,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1497,6 +1497,98 @@ h3 {
   font-size: 0.84rem;
 }
 
+.ai-delivery-section {
+  padding: clamp(4rem, 6vw, 6rem) 0;
+  color: var(--cream);
+  background: var(--night);
+}
+
+.ai-delivery-section .eyebrow {
+  color: #f18268;
+}
+
+.ai-delivery-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: end;
+  margin-bottom: clamp(2.5rem, 4vw, 4rem);
+}
+
+.ai-delivery-heading h2 {
+  margin-bottom: 0;
+  font-size: clamp(2rem, 3.5vw, 3.4rem);
+}
+
+.ai-delivery-heading > p {
+  margin: 0;
+  color: #aaa89f;
+  font-size: 0.94rem;
+}
+
+.ai-delivery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-block: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.ai-delivery-step {
+  padding: 1.5rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.ai-delivery-step:last-child {
+  border-right: 0;
+}
+
+.ai-delivery-step span {
+  display: block;
+  margin-bottom: 2.25rem;
+  color: #f18268;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ai-delivery-step h3 {
+  margin-bottom: 1rem;
+  font-size: clamp(1.25rem, 1.8vw, 1.7rem);
+}
+
+.ai-delivery-step p {
+  margin: 0;
+  color: #b6b3aa;
+  font-size: 0.88rem;
+}
+
+.ai-delivery-footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.ai-delivery-footer p {
+  margin: 0;
+  color: #aaa89f;
+  font-size: 0.82rem;
+}
+
+.ai-delivery-footer strong {
+  color: var(--cream);
+}
+
+.ai-delivery-footer .text-link {
+  flex: 0 0 auto;
+  font-size: 0.86rem;
+}
+
+.ai-delivery-section + .services-page-section {
+  padding-top: 4.5rem;
+}
+
 .services-advisory-section .section-heading {
   margin-bottom: 2.5rem;
 }
@@ -2056,6 +2148,7 @@ h3 {
   .continuum-feature,
   .section-heading,
   .architecture-heading,
+  .ai-delivery-heading,
   .closing-cta-grid,
   .story-grid,
   .service-detail,
@@ -2132,6 +2225,28 @@ h3 {
 
   .architecture-evidence {
     grid-template-columns: 1fr;
+  }
+
+  .ai-delivery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ai-delivery-step {
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+  }
+
+  .ai-delivery-step:last-child {
+    border-bottom: 0;
+  }
+
+  .ai-delivery-step span {
+    margin-bottom: 1.25rem;
+  }
+
+  .ai-delivery-footer {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .home-section .about-strip {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1605,7 +1605,7 @@ h3 {
   font-style: italic;
 }
 
-.timeline-item h3 {
+.timeline-item h2 {
   margin: 3rem 0 1rem;
 }
 
@@ -1664,7 +1664,7 @@ h3 {
   padding: 1.5rem;
 }
 
-.about-page-section .timeline-item h3 {
+.about-page-section .timeline-item h2 {
   margin-top: 2rem;
   font-size: clamp(1.2rem, 1.6vw, 1.55rem);
 }
@@ -1684,6 +1684,106 @@ h3 {
 
 .about-story-grid .story-copy {
   font-size: 0.98rem;
+}
+
+.about-architecture {
+  padding: clamp(4rem, 6vw, 6rem) 0;
+  color: var(--cream);
+  background: var(--night);
+}
+
+.about-architecture .eyebrow {
+  color: #f18268;
+}
+
+.architecture-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: end;
+  margin-bottom: clamp(2.5rem, 4vw, 4rem);
+}
+
+.architecture-heading h2 {
+  max-width: 720px;
+  margin-bottom: 0;
+  font-size: clamp(2rem, 3.5vw, 3.4rem);
+}
+
+.architecture-heading > p {
+  margin: 0;
+  color: #aaa89f;
+  font-size: 0.94rem;
+}
+
+.architecture-principles {
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.architecture-principle {
+  display: grid;
+  grid-template-columns: 70px minmax(210px, 0.62fr) 1fr;
+  gap: 2rem;
+  align-items: start;
+  padding: 1.4rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.architecture-principle span {
+  color: #f18268;
+  font-family: Georgia, serif;
+  font-style: italic;
+}
+
+.architecture-principle h3,
+.architecture-principle p {
+  margin: 0;
+}
+
+.architecture-principle h3 {
+  font-size: clamp(1.2rem, 1.65vw, 1.55rem);
+}
+
+.architecture-principle p {
+  color: #b6b3aa;
+  font-size: 0.9rem;
+}
+
+.architecture-evidence {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.architecture-proof {
+  padding: 1.35rem;
+  background: var(--night-soft);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: var(--radius-sm);
+}
+
+.architecture-proof h3 {
+  display: block;
+  margin-bottom: 1rem;
+  color: #f18268;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.architecture-proof p {
+  margin: 0;
+  color: #cac7bd;
+  font-size: 0.84rem;
+}
+
+.architecture-link {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 2rem;
 }
 
 .about-page-section .section-heading {
@@ -1955,6 +2055,7 @@ h3 {
   .hero-grid,
   .continuum-feature,
   .section-heading,
+  .architecture-heading,
   .closing-cta-grid,
   .story-grid,
   .service-detail,
@@ -2018,6 +2119,19 @@ h3 {
 
   .principle-item p {
     grid-column: 2;
+  }
+
+  .architecture-principle {
+    grid-template-columns: 50px 1fr;
+    gap: 1rem;
+  }
+
+  .architecture-principle p {
+    grid-column: 2;
+  }
+
+  .architecture-evidence {
+    grid-template-columns: 1fr;
   }
 
   .home-section .about-strip {
@@ -2130,7 +2244,8 @@ h3 {
   .case-facts,
   .service-detail-lists,
   .project-form,
-  .footer-grid {
+  .footer-grid,
+  .architecture-evidence {
     grid-template-columns: 1fr;
   }
 
@@ -2159,6 +2274,18 @@ h3 {
 
   .practice-map {
     width: 100%;
+  }
+
+  .architecture-principle {
+    grid-template-columns: 38px 1fr;
+  }
+
+  .architecture-proof {
+    padding: 1.15rem;
+  }
+
+  .architecture-link {
+    justify-content: flex-start;
   }
 
   .case-title-row {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -512,14 +512,8 @@ h3 {
 }
 
 .home-section .about-strip {
-  grid-template-columns: 150px minmax(0, 1fr);
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: clamp(2rem, 5vw, 5rem);
-}
-
-.home-section .about-monogram {
-  width: 140px;
-  height: 170px;
-  font-size: 2.5rem;
 }
 
 .home-section .about-copy h2 {
@@ -1042,23 +1036,90 @@ h3 {
 
 .about-strip {
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr);
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: clamp(2rem, 7vw, 7rem);
   align-items: start;
 }
 
-.about-monogram {
-  display: grid;
-  width: 170px;
-  height: 210px;
-  place-items: center;
-  color: var(--paper);
-  background: var(--signal);
-  border-radius: 50% 50% 45% 45% / 42% 42% 58% 58%;
-  font-family: Georgia, serif;
-  font-size: 3rem;
-  font-style: italic;
-  transform: rotate(-3deg);
+.practice-map {
+  padding: 1rem 1rem 1.15rem;
+  color: var(--cream);
+  background: var(--night);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  box-shadow: 0 18px 45px rgba(39, 33, 23, 0.12);
+}
+
+.practice-map__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.85rem;
+  color: #9d9b93;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.58rem;
+  font-weight: 780;
+  letter-spacing: 0.11em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.practice-map__path {
+  padding: 0 0 0 0.85rem;
+  margin: 1rem 0 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.2);
+  list-style: none;
+}
+
+.practice-map__path li {
+  position: relative;
+  padding: 0 0 0.9rem 0.85rem;
+}
+
+.practice-map__path li:last-child {
+  padding-bottom: 0;
+}
+
+.practice-map__path li::before {
+  position: absolute;
+  top: 0.28rem;
+  left: calc(-0.85rem - 4px);
+  width: 7px;
+  height: 7px;
+  content: "";
+  background: #77756e;
+  border: 2px solid var(--night);
+  border-radius: 50%;
+}
+
+.practice-map__path .practice-map__origin::before {
+  background: #f07054;
+  box-shadow: 0 0 0 4px rgba(240, 112, 84, 0.14);
+}
+
+.practice-map__path span,
+.practice-map__path strong {
+  display: block;
+}
+
+.practice-map__path span {
+  margin-bottom: 0.15rem;
+  color: #96948c;
+  font-size: 0.55rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.practice-map__path strong {
+  color: #ddd9cf;
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.practice-map__path .practice-map__origin strong {
+  color: var(--cream);
 }
 
 .about-copy h2 {
@@ -1963,10 +2024,8 @@ h3 {
     grid-template-columns: 1fr;
   }
 
-  .home-section .about-monogram {
-    width: 110px;
-    height: 135px;
-    font-size: 2rem;
+  .home-section .practice-map {
+    width: min(100%, 360px);
   }
 }
 
@@ -2098,10 +2157,8 @@ h3 {
     grid-template-columns: 1fr;
   }
 
-  .about-monogram {
-    width: 110px;
-    height: 135px;
-    font-size: 2rem;
+  .practice-map {
+    width: 100%;
   }
 
   .case-title-row {


### PR DESCRIPTION
## Summary

This PR strengthens the portfolio site's positioning around senior product engineering, architecture, and credible AI-enabled delivery.

It replaces the unclear `SK` monogram/ribbon on the homepage with a clearer practice map, expands the About page so the engineering story has more depth, and adds a commercially useful AI delivery section to Services without overstating AI specialization.

## What changed

### Homepage

- Replaced the `SK` visual mark with a practice map that shows how the work has expanded from Android into desktop, web, architecture, product, and launch.
- Updated the hero copy to mention product thinking, architecture, AI-assisted engineering, design systems, and launch execution.
- Changed the capability label from `Engineering` to `Architecture & engineering`.
- Changed `Automation` to `AI + automation` in the capability band.
- Strengthened the About teaser with clearer references to boundaries, explicit state, maintainability, and complete product delivery.

### About page

- Reframed the story timeline around three stages:
  - Mobile engineering
  - Product architecture
  - Complete products
- Added a dark architecture section: `Architecture is how a product stays changeable.`
- Introduced outcome-led architecture principles around local change, explicit behavior, and continuation.
- Added public project evidence from GitGlow, Continuum, and Green Compass.
- Replaced vaguer language such as connected systems with clearer product architecture language.
- Updated the working principle around automation to `Keep judgment in the loop`, positioning AI and automation as accelerators that still require human review.
- Updated the About page description to include product architecture.

### Services page

- Added a focused AI delivery section: `Models in the loop. Judgment at the center.`
- Positioned AI as a disciplined product delivery advantage across exploration, building, QA, documentation, launch assets, and repeatable production workflows.
- Added a clear human-review guardrail so the copy does not imply unchecked model output or outsourced responsibility.
- Linked the section to the existing public writing piece, `Your Design System Is Already a Marketing Engine`, as proof of AI-assisted production workflow thinking.
- Renamed the advisory card to `AI workflow review` and made the offer more concrete: identify useful leverage, define guardrails, and shape one small workflow worth testing.

### Styling

- Added responsive styling for the new homepage practice map.
- Added the dark architecture band on About with responsive grids for principles and evidence.
- Added the dark AI delivery band on Services with a three-part workflow grid.
- Added responsive rules below 900px so the new architecture and AI sections stack cleanly on smaller screens.

## Why

The previous site already communicated broad product experience, but it undersold the engineering depth behind that breadth. The new copy makes architecture legible in buyer-relevant terms: products that can evolve safely, behave predictably, avoid costly rewrites, and remain maintainable after handoff.

The AI positioning is intentionally practical. It presents Stoyan as an AI-enabled product engineer, not an AI specialist, ML researcher, or custom-model vendor. That keeps the claim credible while still making the delivery advantage sellable.

## Impact

- Business readers get a clearer reason to trust the engineering judgment behind the product work.
- Technical readers see stronger signals around architecture, state, maintainability, and testing discipline.
- The Services page now has a more actionable AI entry point for clients who want faster delivery but still need responsible review and ownership.
- No routes, APIs, schemas, or interactive behavior changed.

## Validation

- Ran `npm run build` successfully.
- Astro check completed with 0 errors, 0 warnings, and 0 hints.
- Production static build completed successfully with 12 pages generated.
- Reviewed the copy to avoid unsupported AI claims such as agents, RAG, custom models, ML research, or production customer-facing AI integrations.
- Preserved the SK-to-practice-map replacement and did not restore the monogram.