### PR TITLE
Update Continuum product URL

### DIFF
--- a/src/data/work/continuum.md
+++ b/src/data/work/continuum.md
@@ -16,7 +16,7 @@ proofPoints:
   - Focused macOS quick-calculation companion
   - Product tokens reused across launch assets
 image: /assets/images/projects/Continuum.png
-externalUrl: https://continuum-landing-ivory.vercel.app/
+externalUrl: https://cntnm.xyz/
 featuredOrder: 1
 disclosure: teaser
 accent: "#7157d9"


### PR DESCRIPTION
## Summary

Updates the Continuum project metadata so every site CTA that reads from the shared work entry now points to the new production domain: `https://cntnm.xyz/`.

## What changed

- Replaced the old Vercel preview URL in `src/data/work/continuum.md` with `https://cntnm.xyz/`.
- Left the consuming Astro pages unchanged because they already use `continuum.data.externalUrl`, so the homepage and Continuum case-study CTAs inherit the corrected destination from one source.

## Why

Continuum now has its own purchased domain, and public links from the portfolio should send visitors to the canonical product URL instead of the previous Vercel preview deployment.

## Impact

- Homepage “View Continuum” CTA now points to `cntnm.xyz`.
- Continuum case-study CTAs now point to `cntnm.xyz`.
- No layout, copy, routing, or sitemap behavior changed.

## Validation

- Confirmed the old `continuum-landing-ivory.vercel.app` URL no longer appears in the source.
- Ran `npm run build` successfully.
- Astro check completed with 0 errors and 0 warnings.