### PR TITLE
Feature the latest Continuum product story

### DIFF
--- a/src/data/writing/continuum-beyond-browser.md
+++ b/src/data/writing/continuum-beyond-browser.md
@@ -1,0 +1,16 @@
+---
+title: Continuum Has Grown Beyond the Browser
+description: How a live calculation editor grew into a local-first workspace, a macOS companion, and a complete path from passing thought to durable model.
+publishedAt: 2026-07-28
+topics:
+  - Local-first
+  - Product design
+  - macOS
+  - Decision making
+canonicalUrl: https://skorudzhiev.medium.com/continuum-has-grown-beyond-the-browser-b91915e7ab62
+mediumUrl: https://skorudzhiev.medium.com/continuum-has-grown-beyond-the-browser-b91915e7ab62
+relatedWork: continuum
+relatedCapability: End-to-end product engineering
+featured: true
+external: true
+---

--- a/src/data/writing/git-analytics-local-first.md
+++ b/src/data/writing/git-analytics-local-first.md
@@ -10,6 +10,6 @@ canonicalUrl: https://medium.com/p/3602f8893139
 mediumUrl: https://medium.com/p/3602f8893139
 relatedWork: gitglow
 relatedCapability: Product clarity and prototyping
-featured: true
+featured: false
 external: true
 ---

--- a/src/pages/work/continuum.astro
+++ b/src/pages/work/continuum.astro
@@ -6,6 +6,7 @@ import { siteConfig } from "../../site-config";
 const continuum = await getEntry("work", "continuum");
 if (!continuum) throw new Error("Continuum work entry is missing");
 const designSystemArticle = await getEntry("writing", "design-system-marketing-engine");
+const continuumStoryArticle = await getEntry("writing", "continuum-beyond-browser");
 ---
 
 <BaseLayout title="Continuum — product case study" description="A restrained case-study preview of Continuum: a local-first calculation workspace, macOS companion, and connected launch system.">
@@ -30,7 +31,16 @@ const designSystemArticle = await getEntry("writing", "design-system-marketing-e
   </header>
 
   <section class="shell">
-    <div class="teaser-note">This is a restrained preview while the product approaches launch. It focuses on the public product thesis and the shape of the work without exposing private implementation details.</div>
+    <div class="teaser-note">
+      <div>
+        <p>This is a restrained preview while the product approaches launch. It focuses on the public product thesis and the shape of the work without exposing private implementation details.</p>
+        {continuumStoryArticle && (
+          <a class="text-link" href={continuumStoryArticle.data.canonicalUrl} target="_blank" rel="noopener">
+            Read the current Continuum product story <span aria-hidden="true">↗</span>
+          </a>
+        )}
+      </div>
+    </div>
   </section>
 
   <section class="story-grid continuum-story-grid shell">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1396,6 +1396,14 @@ h3 {
   text-transform: uppercase;
 }
 
+.teaser-note p {
+  margin: 0;
+}
+
+.teaser-note .text-link {
+  margin-top: 0.55rem;
+}
+
 .services-stack {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary

Adds the newly published **“Continuum Has Grown Beyond the Browser”** article to the portfolio’s writing system and connects it to the Continuum case study.

## What changed

- Added a new writing collection entry with the article’s canonical Medium URL, publication date, topics, related Continuum work, and capability metadata.
- Marked the article as featured so it becomes the lead story on `/writing/` and appears in the homepage’s selected writing section.
- Added a contextual “Read the current Continuum product story” link to the restrained preview note on `/work/continuum/`.
- Added small supporting styles for the linked preview note.
- Rotated the older Git analytics article from the featured set into the archive, preserving a balanced three-story featured layout while keeping the article discoverable.
- Allowed the existing RSS generation to include the new article automatically.

## Why

This article is now the clearest public account of how Continuum evolved from a browser-based calculation editor into a broader local-first product spanning the full workspace, a macOS companion, and Quick Calculation. Featuring it gives visitors a current narrative behind the product while the case study intentionally remains a restrained pre-launch preview.

The placement is deliberately focused: Writing is the primary home, the homepage provides discovery, and the Continuum case study supplies product context. About, Services, and global navigation remain unchanged to avoid repetitive promotion.

## User impact

- Visitors see the newest Continuum story first in the Writing section.
- Homepage visitors can discover the article without navigating into the archive.
- Case-study readers can move directly from the high-level product preview to the detailed public build story.
- RSS subscribers receive the new article with its relevant topic categories.

## Validation

- `astro check` — 0 errors, 0 warnings, 0 hints
- `astro build` — successful static production build (12 pages)
- `git diff --check` — clean
- Rendered `/writing/`, `/`, and `/work/continuum/` locally and confirmed the expected article placements.
- Checked rendered browser logs — no warnings or errors.
- Confirmed the generated RSS feed contains the new article and canonical URL.